### PR TITLE
fixed the "favicon" path issue in gatsby-config

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -33,7 +33,7 @@ const config: GatsbyConfig = {
     {
       resolve: 'gatsby-plugin-manifest',
       options: {
-        "icon": `images/favicon.png`
+        "icon": `static/images/favicon.png`
       }
     },
     {


### PR DESCRIPTION
FIxed the bug where the favicon was not appearing.

The problem was fixed by correcting the path in the `gatsby-config.ts` to be relative to the root.